### PR TITLE
(SIMP-1167) Issue in krb5kdc_auto_keytabs provider

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jul 11 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.2-0
+- Fixed a bug in the krb5kdc_auto_keytab provider where passed hosts were not
+  getting the realms array integrated.
+
 * Thu Jun 30 2016 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.1-0
 - Haveged now included by default.
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :test do
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts", "~> 1.3"
-  gem "vagrant-wrapper"
 
 
   # simp-rake-helpers does not suport puppet 2.7.X

--- a/lib/puppet/provider/krb5kdc_auto_keytabs/generate.rb
+++ b/lib/puppet/provider/krb5kdc_auto_keytabs/generate.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:krb5kdc_auto_keytabs).provide :generate do
     host_hash ||= {}
 
     # No reason to do all the processing if we're just trying to delete things
-    return File.directory?(target_dir) if resource[:ensure] == :absent
+    return File.directory?(target_dir) if resource[:ensure].to_s == 'absent'
 
     principal_list = execute(%(#{command(:kadmin)} -q "list_principals")).split.map(&:strip)
 
@@ -98,6 +98,11 @@ Puppet::Type.type(:krb5kdc_auto_keytabs).provide :generate do
     # Process ALL THE HOSTS
     host_hash.keys.sort.each do |hostname|
       host = host_hash[hostname].dup
+
+      # If we've been told to add hosts to specific realms, we need to add them
+      # to the array.
+      host['realms'] += target_realms
+      host['realms'].uniq!
 
       (host['realms'] - valid_realms).each do |realm|
         host['realms'].delete(realm)

--- a/lib/puppet/type/krb5kdc_auto_keytabs.rb
+++ b/lib/puppet/type/krb5kdc_auto_keytabs.rb
@@ -214,6 +214,8 @@ Puppet::Type.newtype(:krb5kdc_auto_keytabs) do
       value.each_key do |host|
         if value[host]['realms']
           value[host]['realms'] = value[host]['realms'].flatten.map(&:upcase)
+        else
+          value[host]['realms'] = []
         end
 
         value[host]['services'].flatten! if value[host]['services']
@@ -221,6 +223,8 @@ Puppet::Type.newtype(:krb5kdc_auto_keytabs) do
         if @resource[:global_services] && !@resource[:global_services].empty?
           value[host]['services'] ||= []
           value[host]['services'] += @resource[:global_services]
+        else
+          value[host]['services'] = []
         end
       end
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-krb5",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author":  "simp",
   "summary": "Puppet management of the MIT kerberos stack",
   "license": "Apache-2.0",


### PR DESCRIPTION
There was an issue where the provider was not integrating any
explicitly passed realms at the time of creation.

SIMP-1167 #comment Issue with provider found during NFS testing

Change-Id: I1c3413e1a184693948e645971da922970213fd7b