### PR TITLE
(SIMP-1167) Documentation mismatch discovered

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Jul 22 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.3-0
+- The Realm KDC must be explicitly specified
+
 * Mon Jul 11 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.2-0
 - Fixed a bug in the krb5kdc_auto_keytab provider where passed hosts were not
   getting the realms array integrated.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-krb5",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author":  "simp",
   "summary": "Puppet management of the MIT kerberos stack",
   "license": "Apache-2.0",

--- a/templates/realm.erb
+++ b/templates/realm.erb
@@ -1,20 +1,19 @@
-<%
-  _defvars = [
-    'admin_server',
-    'kdc',
-    'default_domain',
-    'v4_realm',
-    'auth_to_local'
-  ]
--%>
 [realms]
   <%= @name.upcase %> = {
-<% _defvars.each do |key|
-  val = eval("@#{key}")
-  unless val.nil? || val.empty?
--%>
-    <%= key %> = <%= val %>
-<%  end -%>
+    admin_server = <%= @admin_server %>
+<% if @kdc.empty? -%>
+    kdc = <%= @admin_server %>
+<% else -%>
+    kdc = <%= @kdc %>
+<% end -%>
+<% unless @default_domain.empty? -%>
+    default_domain = <%= @default_domain %>
+<% end -%>
+<% unless @v4_realm.empty? -%>
+    v4_realm = <%= @v4_realm %>
+<% end -%>
+<% unless @auth_to_local.empty? -%>
+    auth_to_local = <%= @auth_to_local %>
 <% end -%>
 <% unless @v4_instance_convert.empty? -%>
     v4_instance_convert = {


### PR DESCRIPTION
When specifying a realm, you must specify both the admin server and KDC
despite some documentation sources indicating that you can specify one
or the other.

SIMP-1167 #comment The realm KDC must be explicitly specified

Change-Id: Id96f4030df8f523ef733a4426f024e25bec5aefe