### PR TITLE
(SIMP-1167) Ordering issue in krb5::keytab

### DIFF
--- a/manifests/keytab.pp
+++ b/manifests/keytab.pp
@@ -23,7 +23,8 @@ class krb5::keytab (
   }
 
   file { '/etc/krb5.keytab':
-    ensure => 'file',
-    source => "/etc/krb5_keytabs/${::fqdn}.keytab"
+    ensure  => 'file',
+    source  => "file:///etc/krb5_keytabs/${::fqdn}.keytab",
+    require => File['/etc/krb5_keytabs']
   }
 }


### PR DESCRIPTION
I keep forgetting that file sources that are local files don't
autorequire other file resources on the system. Definitely need to file
a bug on this.

SIMP-1167 #comment Ordering Issue

Change-Id: I25c1e9b4eac97e1253da6885e3cc23f00c731e43