### PR TITLE
(SIMP-1398) Kerberos and NFS

### DIFF
--- a/manifests/setting/realm.pp
+++ b/manifests/setting/realm.pp
@@ -54,7 +54,7 @@ define krb5::setting::realm (
   file { "${target}/${_name}__realm":
     owner   => 'root',
     group   => 'root',
-    mode    => '0600',
+    mode    => '0644',
     seltype => 'krb5_conf_t',
     content => template('krb5/realm.erb')
   }


### PR DESCRIPTION
  The permissions on the realm configuration file were set to
  strict and the service could not read them.
SIMP-1398 #updates
