### PR TITLE
(SIMP-1574) Fix Forge `haveged` dependency name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.7-0
+- Fix Forge `haveged` dependency name
+
 * Thu Sep 01 2016 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.6-0
 - Ensure that the /etc/krb5.simp.d/realm* files are mode 644
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ end
 group :system_tests do
   #gem 'beaker'
   # Need this for SELinux workarounds until the PR gets accepted
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker', :ref => 'BKR-896'
+  gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', '>= 1.0.5'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,18 @@
 {
-  "name":    "simp-krb5",
-  "version": "5.0.6",
-  "author":  "simp",
+  "name": "simp-krb5",
+  "version": "5.0.7",
+  "author": "simp",
   "summary": "Puppet management of the MIT kerberos stack",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-krb5",
+  "source": "https://github.com/simp/pupmod-simp-krb5",
   "project_page": "https://github.com/simp/pupmod-simp-krb5",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp"
+  ],
   "dependencies": [
     {
-      "name": "simp/puppet-haveged",
+      "name": "simp/haveged",
       "version_requirement": ">= 0.3.0 < 1.0.0"
     },
     {


### PR DESCRIPTION
`metadata.json` erroneously claimed `simp/puppet-haveged` as a
dependency, which causes a fatal error when pushing to the Forge.

This patch corrects the dependency name  to `simp/haveged`.

SIMP-1574 #comment fixed pupmod-simp-krb5