### PR TITLE
WIP (SIMP-3836) krb5: spec tests fail when domain fact isn't available

### DIFF
--- a/lib/puppet/type/krb5kdc_auto_keytabs.rb
+++ b/lib/puppet/type/krb5kdc_auto_keytabs.rb
@@ -146,8 +146,6 @@ Puppet::Type.newtype(:krb5kdc_auto_keytabs) do
       The realms under which the hosts should be generated
     EOM
 
-    defaultto(Facter.value(:domain))
-
     validate do |value|
       unless (value.is_a?(String) || value.is_a?(Array)) || (Array(value).count{|x| !x.is_a?(String)} == 0)
         raise(Puppet::Error, "'$realms' must be a String or Array of Strings, not '#{value.class}'")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,6 +138,13 @@ RSpec.configure do |c|
     end
   end
 
+
+  if ENV.fetch('DEBUG','no') == 'yes'
+    Puppet.debug=true
+    Puppet::Util::Log.level = :debug
+    Puppet::Util::Log.newdestination(:console)
+  end
+
   c.after(:each) do
     # clean up the mocked environmentpath
     FileUtils.rm_rf(@spec_global_env_temp)

--- a/spec/unit/puppet/type/krb5kdc_auto_keytabs_spec.rb
+++ b/spec/unit/puppet/type/krb5kdc_auto_keytabs_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:krb5kdc_auto_keytabs) do
+
   context 'when generating keys' do
     let :krb5kdc_auto_keytabs do
+      Facter.stubs(:value).with(:domain).returns('example.com')
       Puppet::Type.type(:krb5kdc_auto_keytabs).new(:name => '/var/kerberos/krb5kdc/auto_keytabs')
     end
 
@@ -117,7 +119,7 @@ describe Puppet::Type.type(:krb5kdc_auto_keytabs) do
     end
 
     it "should upcase all realms in the :hosts hash" do
-     expect(
+      expect(
         Puppet::Type.type(:krb5kdc_auto_keytabs).new(
           :name  => '/var/kerberos/krb5kdc/auto_keytabs',
           :hosts =>  {


### PR DESCRIPTION
The `krb5kdc_auto_keytabs` type was failing to compile if the `domain` fact was nil, and the `realms` attribute used it in its default. The default for that attribute has been removed, since it should always be set when using the `krb5::kdc::auto_keytabs` class. 

SIMP-3826 #close