### PR TITLE
(SIMP-6110) Use (namespaced) simplib::passgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.5-0
+- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
+  Puppet 3 function.
+- Use simplib::validate_re_array() in lieu of validate_re_array(),
+  a deprecated simplib Puppet 3 function.
+- Removed unnecessary use of validate_port() on parameters of type
+  Simplib::Port
+
 * Wed Nov 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.4-0
 - Update badges and contribution guide URL in README.md
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
 
 Management of the MIT Kerberos Stack
 
-This module is a component of the `System Integrity Management Platform`, a compliance-oriented systems management framework built on `Puppet`.
+This module is a component of the [System Integrity Management Platform](https://simp-project.com),
+a compliance-management framework built on Puppet.
 
 This module is designed for use within a larger SIMP ecosystem, but many of its functions can be used independently.
 
@@ -212,7 +213,7 @@ Once this is complete, the keys will be propagated across your environment per
 
 ### Integration with SIMP NFS Module
 
-Please see our [NFS module documentation](https://github.com/simp/pupmod-simp-nfs) or our [online documentation](http://simp.readthedocs.io/en/master/user_guide/HOWTO/NFS.html) for
+Please see our [NFS module documentation](https://github.com/simp/pupmod-simp-nfs) or our [online documentation](https://simp.readthedocs.io/en/stable/user_guide/HOWTO/NFS.html) for
 information on how to integrate KRB5 with NFS.
 
 ## Limitations
@@ -221,12 +222,9 @@ SIMP Puppet modules are generally intended to be used on a Red Hat Enterprise Li
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net).
-
-[System Integrity Management Platform](https://simp-project.com)
-
 
 ## Acceptance tests
 

--- a/manifests/kdc/config.pp
+++ b/manifests/kdc/config.pp
@@ -38,7 +38,7 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class krb5::kdc::config (
-  String               $kdb5_password = passgen('kdb5kdc','1024'),
+  String               $kdb5_password = simplib::passgen('kdb5kdc', { 'length' => 1024 }),
   Array[Simplib::Port] $kdc_ports     = [88, 750],
   Array[Simplib::Port] $kdc_tcp_ports = [88, 750]
 ) inherits ::krb5::kdc {
@@ -48,10 +48,6 @@ class krb5::kdc::config (
   $_trusted_nets = getvar('::krb5::kdc::trusted_nets')
   $_config_dir = getvar('::krb5::kdc::config_dir')
   $_firewall = getvar('::krb5::kdc::firewall')
-
-  #validate_string($kdb5_password)
-  validate_port($kdc_ports)
-  validate_port($kdc_tcp_ports)
 
   $_kdc_ports = join($kdc_ports,',')
   $_kdc_tcp_ports = join($kdc_tcp_ports,',')

--- a/manifests/kdc/realm.pp
+++ b/manifests/kdc/realm.pp
@@ -113,7 +113,7 @@ define krb5::kdc::realm (
 
       $_possible_principal_flag_check_string = join($_possible_principal_flags, '|')
 
-      validate_re_array(
+      simplib::validate_re_array(
         $_default_principal_flags,
         "^([+-]?(${_possible_principal_flag_check_string}))"
       )

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-krb5",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "author": "SIMP Team",
   "summary": "Puppet management of the MIT kerberos stack",
   "license": "Apache-2.0",
@@ -25,7 +25,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
  Puppet 3 function.
- Use simplib::validate_re_array() in lieu of validate_re_array(),
  a deprecated simplib Puppet 3 function.
- Removed unnecessary use of validate_port() on parameters of type
  Simplib::Port

SIMP-6110 #comment pupmod-simp-krb5