### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 ---
 fixtures:
   repositories:
-    haveged:
-      repo: https://github.com/simp/puppet-haveged
-      branch: simp-master
+    haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simplib: https://github.com/simp/pupmod-simp-simplib

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
   a deprecated simplib Puppet 3 function.
 - Removed unnecessary use of validate_port() on parameters of type
   Simplib::Port
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
 
 * Wed Nov 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.4-0
 - Update badges and contribution guide URL in README.md

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ SIMP Puppet modules are generally intended to be used on a Red Hat Enterprise Li
 
 ## Development
 
-Please read our [Contribution Guide](https://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net).
 

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-krb5