### PR TITLE
(SIMP-6909) (SIMP-6919) (SIMP-6921) (SIMP-6934) Update deps and fix tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,14 +5,11 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.1      4.10.6   2.1.9  TBD
-# SIMP 6.2      4.10.12  2.1.9  TBD
-# SIMP 6.3      5.5.7    2.4.4  TBD***
-# PE 2018.1     5.5.8    2.4.4  2020-05 (LTS)***
+# SIMP 6.3      5.5.10   2.4.5  TBD***
+# PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 ---
 stages:
   - 'sanity'
@@ -65,18 +62,6 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_4: &pup_4
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.0'
-    MATRIX_RUBY_VERSION: '2.1'
-
-.pup_4_10: &pup_4_10
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.10.4'
-    MATRIX_RUBY_VERSION: '2.1'
-
 .pup_5: &pup_5
   image: 'ruby:2.4'
   variables:
@@ -84,21 +69,19 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_7: &pup_5_5_7
+.pup_5_5_10: &pup_5_5_10
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.7'
+    PUPPET_VERSION: '5.5.10'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
 .pup_6: &pup_6
-  allow_failure: true
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
-
 
 # Testing Environments
 #-----------------------------------------------------------------------
@@ -151,10 +134,6 @@ sanity_checks:
 # Linting
 #-----------------------------------------------------------------------
 
-pup4-lint:
-  <<: *pup_4
-  <<: *lint_tests
-
 pup5-lint:
   <<: *pup_5
   <<: *lint_tests
@@ -170,12 +149,8 @@ pup5-unit:
   <<: *pup_5
   <<: *unit_tests
 
-pup5.5.7-unit:
-  <<: *pup_5_5_7
-  <<: *unit_tests
-
-pup4.10-unit:
-  <<: *pup_4_10
+pup5.5.10-unit:
+  <<: *pup_5_5_10
   <<: *unit_tests
 
 pup6-unit:
@@ -184,41 +159,39 @@ pup6-unit:
 
 # Acceptance tests
 # ==============================================================================
-pup4.10:
-  <<: *pup_4_10
+pup5.5.10:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites'
 
-pup4.10-fips:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
-
-pup5.5.7:
-  <<: *pup_5_5_7
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites'
-
-pup5.5.7-fips:
-  <<: *pup_5_5_7
+pup5.5.10-fips:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
 
-pup5.5.7-oel:
-  <<: *pup_5_5_7
+pup5.5.10-oel:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup5.5.7-oel-fips:
-  <<: *pup_5_5_7
+pup5.5.10-oel-fips:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
+pup6:
+  <<: *pup_6
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites'
+
+pup6-fips:
+  <<: *pup_6
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,10 @@ global:
   - STRICT_VARIABLES=yes
 
 jobs:
-  allow_failures:
-    - name: 'Latest Puppet 6.x (allowed to fail)'
-
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -63,21 +60,14 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 4.10 (SIMP 6.2, PE 2016.4)'
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.10.0"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
       name: 'Puppet 5.3 (PE 2017.3)'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.3.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      rvm: 2.4.4
+      rvm: 2.4.5
       name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
@@ -85,20 +75,20 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Latest Puppet 6.x (allowed to fail)'
+      name: 'Latest Puppet 6.x'
       rvm: 2.5.1
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.4
+      rvm: 2.4.5
       script:
         - true
       before_deploy:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 7.0.6-0
+- Support puppetlabs/stdlib 6.x and puppet 6.x.
+
 * Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.5-0
 - Use simplib::passgen() in lieu of passgen(), a deprecated simplib
   Puppet 3 function.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
-* Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 7.0.6-0
+* Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 7.1.0-0
+- Remove Puppet 4 support
+- Add Puppet 6 support
+- Add puppetlabs-stdlib 6 support
 - Support puppetlabs/stdlib 6.x and puppet 6.x.
 
 * Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.5-0

--- a/lib/puppet/provider/krb5kdc_auto_keytabs/generate.rb
+++ b/lib/puppet/provider/krb5kdc_auto_keytabs/generate.rb
@@ -212,7 +212,7 @@ Puppet::Type.type(:krb5kdc_auto_keytabs).provide :generate do
           end
         end
       else
-        Puppet.warn("Could not add '#{princ_name}' to keytab at '#{princ[:keytab]}'")
+        Puppet.warning("Could not add '#{princ_name}' to keytab at '#{princ[:keytab]}'")
         FileUtils.rm_f(princ[:tmp_keytab])
       end
     end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-krb5",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "author": "SIMP Team",
   "summary": "Puppet management of the MIT kerberos stack",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -58,7 +58,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 6.0.0"
+      "version_requirement": ">= 4.10.4 < 7.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-krb5",
-  "version": "7.0.6",
+  "version": "7.1.0",
   "author": "SIMP Team",
   "summary": "Puppet management of the MIT kerberos stack",
   "license": "Apache-2.0",
@@ -58,7 +58,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 7.0.0"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -18,7 +18,8 @@ HOSTS:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+
   el7.test:
     roles:
       - client
@@ -29,7 +30,7 @@ HOSTS:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 CONFIG:
   log_level: verbose
   type: aio

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -18,7 +18,7 @@ HOSTS:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
   oel7.test:
     roles:
       - client
@@ -29,7 +29,7 @@ HOSTS:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 CONFIG:
   log_level: verbose
   type: aio


### PR DESCRIPTION
- Add Puppet 6 support
- Add puppetlabs-stdlib 6 support
- Fix EPEL key URLs in tests
- Drop Puppet 4 support
- Fix method used to emit a warning in krb5kdc_auto_keytabs provider.  That method
  did not work in Puppet 6

SIMP-6919 #comment pupmod-simp-krb5
SIMP-6909 #comment pupmod-simp-krb5
SIMP-6934 #comment pupmod-simp-krb5