### PR TITLE
(SIMP-10204) Ensure testing with CentOS 8.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.3'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -14,23 +14,13 @@ HOSTS:
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   el8.test:
     roles:
       - client
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -14,11 +14,6 @@ HOSTS:
     platform: el-7-x86_64
     box: generic/oracle7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   el8.test:
     roles:
@@ -26,11 +21,6 @@ HOSTS:
     platform: el-8-x86_64
     box: generic/oracle8
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -7,8 +7,6 @@ describe 'krb5 class' do
   hosts.each do |host|
 
     context 'default setup' do
-      install_package(host,'epel-release')
-
       let(:manifest) { %(include 'krb5') }
 
       it 'should work with no errors' do

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -7,11 +7,12 @@ describe 'krb5::client' do
   end
 
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:server_facts] = server_facts_hash unless (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0'))
-          facts
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
         end
 
         context 'with default parameters' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -19,11 +19,12 @@ describe 'krb5' do
   end
 
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:server_facts] = server_facts_hash unless (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0'))
-          facts
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
         end
 
         context 'with default parameters' do

--- a/spec/classes/kdc_spec.rb
+++ b/spec/classes/kdc_spec.rb
@@ -45,11 +45,12 @@ end
 
 describe 'krb5::kdc' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:server_facts] = server_facts_hash unless (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0'))
-          facts
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
         end
 
         context 'with default parameters' do

--- a/spec/classes/keytab_spec.rb
+++ b/spec/classes/keytab_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 describe 'krb5::keytab' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:server_facts] = server_facts_hash unless (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0'))
-          facts
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
         end
 
         it { is_expected.to compile.with_all_deps }

--- a/spec/defines/kdc/realm_spec.rb
+++ b/spec/defines/kdc/realm_spec.rb
@@ -24,11 +24,12 @@ end
 
 describe 'krb5::kdc::realm' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:server_facts] = server_facts_hash unless (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0'))
-          facts
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
         end
 
         let(:pre_condition) { 'include krb5::kdc' }

--- a/spec/defines/setting/domain_realm_spec.rb
+++ b/spec/defines/setting/domain_realm_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 describe 'krb5::setting::domain_realm' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:server_facts] = server_facts_hash unless (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0'))
-          facts
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
         end
 
         let(:pre_condition) { 'include krb5' }

--- a/spec/defines/setting/realm_spec.rb
+++ b/spec/defines/setting/realm_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 describe 'krb5::setting::realm' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:server_facts] = server_facts_hash unless (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0'))
-          facts
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
         end
 
         let(:pre_condition) { 'include krb5' }

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 describe 'krb5::setting' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts[:server_facts] = server_facts_hash unless (Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0'))
-          facts
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
         end
 
         let(:pre_condition){ 'include ::krb5' }


### PR DESCRIPTION
- Update tests:
  - update the EL8 nodes in the acceptance tests
    to run with generic/centos8 to make sure they using
    CentOS 8.4
  - remove epel repos from nodeset.  Epel repos are installed by default
    by linux_errata in simp beaker helpers
  - update oel7 node to generic from onyxpoint in nodesets
  - set haveged__rngd_enabled fact to false in unit tests

SIMP-10204 #comment update krb5
SIMP-10227 #close