### PR TITLE
Add GCP support to GLCI

### DIFF
--- a/.github/workflows/pr_glci.yml
+++ b/.github/workflows/pr_glci.yml
@@ -67,7 +67,7 @@ jobs:
     outputs:
       valid: ${{ steps.validate-glci-file.outputs.valid }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -80,11 +80,11 @@ jobs:
 
   contributor-permissions:
     name: 'PR contributor check'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       permitted: ${{ steps.user-repo-permissions.outputs.permitted }}
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         id: user-repo-permissions
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -135,7 +135,7 @@ jobs:
     #     - Not implemented: For some reason, this conditional always fails
     #     - Unnecessary if on>pull_request_target>types doesn't include 'closed'
     if: github.event_name == 'pull_request_target' && ( github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' ) && github.event.pull_request.merged != 'true' && needs.glci-syntax.outputs.valid == 'true' && needs.contributor-permissions.outputs.permitted == 'true'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # Things we'd like to do:
       # - [ ] if there's no GitLab mirror, make one
@@ -145,7 +145,7 @@ jobs:
       #       - "created|waiting_for_resource|preparing|pending|running"
       #       - Exception: don't cancel existing pipeline for our own commit
       # - [x] if PR: force-push branch to GitLab
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: needs.contributor-permissions.outputs.permitted == 'true'
         with:
           clean: true

--- a/.github/workflows/pr_glci_cleanup.yml
+++ b/.github/workflows/pr_glci_cleanup.yml
@@ -40,9 +40,9 @@ jobs:
     # `on` section is inadventently modified without considering the security
     # implications.
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr_glci_manual.yml
+++ b/.github/workflows/pr_glci_manual.yml
@@ -2,7 +2,7 @@
 # ------------------------------------------------------------------------------
 #
 #             NOTICE: **This file is maintained with puppetsync**
-#
+
 # This file is updated automatically as part of a standardized asset baseline.
 #
 # The next baseline sync will overwrite any local changes to this file!
@@ -42,7 +42,7 @@ on:
 jobs:
   glci-syntax:
     name: '.gitlab-ci.yml Syntax'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       valid: ${{ steps.validate-glci-file.outputs.valid }}
       pr_head_ref: ${{ steps.get-pr.outputs.pr_head_ref }}
@@ -50,7 +50,7 @@ jobs:
       pr_head_label: ${{ steps.get-pr.outputs.pr_head_label }}
       pr_head_full_name: ${{ steps.get-pr.outputs.pr_full_name }}
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         id: get-pr
         with:
           github-token: ${{secrets.NO_SCOPE_GITHUB_TOKEN}}
@@ -90,7 +90,7 @@ jobs:
             core.setOutput( 'pr_head_ref', pr.data.head.ref )
             core.setOutput( 'pr_head_label', pr.data.head.label )
             core.setOutput( 'pr_head_full_name', pr.data.head.full_name )
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ steps.get-pr.outputs.pr_head_full_name }}
           ref: ${{ steps.get-pr.outputs.pr_head_sha }}
@@ -106,9 +106,9 @@ jobs:
   trigger-when-user-has-repo-permissions:
     name: 'Trigger CI'
     needs: [ glci-syntax ]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ needs.glci-syntax.outputs.pr_head_full_name }}
           ref: ${{ needs.glci-syntax.outputs.pr_head_sha }}
@@ -129,7 +129,7 @@ jobs:
 ###    needs: [ glci-syntax ]
 ###    name: 'Examine Context contents'
 ###    if: always()
-###    runs-on: ubuntu-18.04
+###    runs-on: ubuntu-latest
 ###    steps:
 ###      - name: Dump contexts
 ###        env:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -32,9 +32,9 @@ env:
 jobs:
   puppet-syntax:
     name: 'Puppet Syntax'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
@@ -44,9 +44,9 @@ jobs:
 
   puppet-style:
     name: 'Puppet Style'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
@@ -58,10 +58,10 @@ jobs:
   ruby-style:
     if: false # TODO Modules will need: rubocop in Gemfile, .rubocop.yml
     name: 'Ruby Style (experimental)'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
@@ -73,9 +73,9 @@ jobs:
 
   file-checks:
     name: 'File checks'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Install Ruby 2.5'
         uses: ruby/setup-ruby@v1
         with:
@@ -86,9 +86,9 @@ jobs:
 
   releng-checks:
     name: 'RELENG checks'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
@@ -97,7 +97,7 @@ jobs:
       - name: 'Tags and changelogs'
         run: |
           bundle exec rake pkg:check_version
-          bundle exec rake pkg:compare_latest_tag
+          bundle exec rake pkg:compare_latest_tag[,true]
           bundle exec rake pkg:create_tag_changelog
       - name: 'Test-build the Puppet module'
         run: 'bundle exec pdk build --force'
@@ -105,7 +105,7 @@ jobs:
   spec-tests:
     name: 'Puppet Spec'
     needs: [puppet-syntax]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         puppet:
@@ -118,7 +118,7 @@ jobs:
     env:
       PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release_rpms.yml
+++ b/.github/workflows/release_rpms.yml
@@ -71,10 +71,15 @@ on:
         description: "Dry run (Test-build RPMs)"
         required: false
         default: 'no'
-      verbose:
-        description: 'Verbose RPM builds when "yes"'
+      #verbose:
+      #  description: 'Verbose RPM builds when "yes"'
+      #  required: false
+      #  default: 'no'
+      rebuild_number:
+        description: 'If this is an RPM rebuild, put the number of the rebuild here'
         required: false
-        default: 'no'
+        default: ''
+
 
 env:
   TARGET_REPO: ${{ (github.event.inputs.target_repo != null && format('{0}/{1}', github.repository_owner, github.event.inputs.target_repo)) || github.repository }}
@@ -99,13 +104,13 @@ jobs:
 
           if [[ "$RELEASE_TAG" =~ ^(simp-|v)?([0-9]+\.[0-9]+\.[0-9]+)(-(rc|RC|[Aa]lpha|[Bb]eta|pre|post)?([0-9]+)?)?$ ]]; then
             if [ -n "${BASH_REMATCH[5]}" ]; then
-              echo "::set-output name=prebuild_number::${BASH_REMATCH[5]#-}"
+              echo "{prebuild_number}={${BASH_REMATCH[5]#-}}" >> $GITHUB_OUTPUT
             fi
             if [ -n "${BASH_REMATCH[3]}" ]; then
-              echo "::set-output name=prebuild_suffix::${BASH_REMATCH[3]#-}"
+              echo "{prebuild_suffix}={${BASH_REMATCH[3]#-}}" >> $GITHUB_OUTPUT
             fi
             if [ -n "${BASH_REMATCH[2]}" ]; then
-              echo "::set-output name=build_semver::${BASH_REMATCH[2]}"
+              echo "{build_semver}={${BASH_REMATCH[2]}}" >> $GITHUB_OUTPUT
             fi
           else
             printf '::error ::Release Tag format is not SemVer, X.Y.Z-R, X.Y.Z-<prerelease>: "%s"\n' "$RELEASE_TAG"
@@ -121,7 +126,7 @@ jobs:
         env:
           AUTOCREATE_RELEASE: ${{ github.event.inputs.autocreate_release }}
           PREBUILD_TAG: ${{ steps.validate-inputs.outputs.prebuild_suffix }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           github-token: ${{ github.event.inputs.target_repo_token || secrets.GITHUB_TOKEN }}
           script: |
@@ -189,7 +194,7 @@ jobs:
             )
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.TARGET_REPO }}
           ref: ${{ env.RELEASE_TAG }}
@@ -221,6 +226,22 @@ jobs:
             printf '::warning ::Added file build/rpm_metadata/release with content "%s"\n' "$(cat build/rpm_metadata/release)"
           fi
 
+      - name: 'Customize RPM Release tag via build/rpm_metadata/release (RPM rebuild)'
+        if: ${{ github.event.inputs.rebuild_number != '' }}
+        env:
+          BUILD_SEMVER: ${{ steps.validate-inputs.outputs.build_semver }}
+          REBUILD_NUMBER: ${{ github.event.inputs.rebuild_number }}
+        run: |
+          mkdir -p build/rpm_metadata
+          # simp-doc uses a unique data format in /release
+          if [[ "$TARGET_REPO" =~ ^simp\/simp-doc$ ]]; then
+            echo "version: $BUILD_SEMVER" > build/rpm_metadata/release
+            echo "release: $REBUILD_NUMBER" > build/rpm_metadata/release
+          else
+            echo "$REBUILD_NUMBER" > build/rpm_metadata/release
+          fi
+          printf '::warning ::Added file build/rpm_metadata/release with content "%s"\n' "$(cat build/rpm_metadata/release)"
+
       - name: >
           Build & Sign RPMs for
           ${{ github.event.inputs.release_tag }}
@@ -234,11 +255,11 @@ jobs:
           simp_core_ref_for_building_rpms: ${{ secrets.SIMP_CORE_REF_FOR_BUILDING_RPMS }}
           simp_builder_docker_image: 'docker.io/simpproject/simp_build_${{ github.event.inputs.build_container_os }}:latest'
           path_to_build: "${{ (github.event.inputs.path_to_build != null && format('{0}/{1}', github.workspace, github.event.inputs.path_to_build)) || github.workspace }}"
-          verbose: ${{ github.event.inputs.verbose }}
+          verbose: 'no'  #${{ github.event.inputs.verbose }}
 
       - name: "Wipe all previous assets from GitHub Release (when clean == 'yes')"
         if: ${{ github.event.inputs.clean == 'yes' && github.event.inputs.dry_run != 'yes' }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         env:
           release_id:  ${{ steps.release-api.outputs.id }}
         with:
@@ -246,18 +267,18 @@ jobs:
           script: |
             const release_id = process.env.release_id
             const [owner, repo] = process.env.TARGET_REPO.split('/')
-            const existingAssets = await github.repos.listReleaseAssets({ owner, repo, release_id })
+            const existingAssets = await github.rest.repos.listReleaseAssets({ owner, repo, release_id })
 
             console.log( `  !! !! Wiping ALL uploaded assets for ${owner}/${repo} release (id: ${release_id})`)
             existingAssets.data.forEach(async function(asset){
               asset_id = asset.id
               console.log( `  !! !! !! Wiping existing asset for ${asset.name} (id: ${asset_id})`)
-              await github.repos.deleteReleaseAsset({ owner, repo, asset_id })
+              await github.rest.repos.deleteReleaseAsset({ owner, repo, asset_id })
             })
 
       - name: "Upload RPM file(s) to GitHub Release (dry_run != 'yes')"
         if: ${{ github.event.inputs.dry_run != 'yes' }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         env:
           rpm_file_paths: ${{ steps.build-and-sign-rpm.outputs.rpm_file_paths }}
           rpm_gpg_file: ${{ steps.build-and-sign-rpm.outputs.rpm_gpg_file }}
@@ -274,12 +295,12 @@ jobs:
             async function clobberAsset (name, owner, repo, release_id ){
               console.log( `  -- clobber asset ${name}: owner: ${owner}  repo: ${repo}  release_id: ${release_id}` )
 
-              const existingAssets = await github.repos.listReleaseAssets({ owner, repo, release_id })
+              const existingAssets = await github.rest.repos.listReleaseAssets({ owner, repo, release_id })
               const matchingAssets = existingAssets.data.filter(item => item.name == name);
               if ( matchingAssets.length > 0 ){
                 asset_id = matchingAssets[0].id
                 console.log( `  !! !! Clobbering existing asset for ${name} (id: ${asset_id})`)
-                await github.repos.deleteReleaseAsset({ owner, repo, asset_id })
+                await github.rest.repos.deleteReleaseAsset({ owner, repo, asset_id })
                 return(true)
               }
               return(false)
@@ -297,7 +318,7 @@ jobs:
               };
 
               console.log( `  == Uploading asset ${name}: ${assetContentType}` )
-              const uploadAssetResponse = await github.repos.uploadReleaseAsset({
+              const uploadAssetResponse = await github.rest.repos.uploadReleaseAsset({
                 owner, repo, release_id, data, name, headers,
               })
               return( uploadAssetResponse );

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: "Assert '${{ github.ref }}' is a tag"
         run: '[[ "$GITHUB_REF" =~ ^refs/tags/ ]] || { echo "::error ::GITHUB_REF is not a tag: ${GITHUB_REF}"; exit 1 ; }'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -74,7 +74,7 @@ jobs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -87,7 +87,6 @@ jobs:
           annotation="$(git for-each-ref "$GITHUB_REF" --format='%(contents)' --count=1)"
           annotation_title="$(echo "$annotation" | head -1)"
 
-
           if [[ "$tag" =~ ^(simp-|v)?[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre|post)?([0-9]+)?)?$ ]]; then
             if [ -n "${BASH_REMATCH[2]}" ]; then
               prerelease=yes
@@ -98,14 +97,15 @@ jobs:
             exit 88
           fi
 
-          echo "::set-output name=tag::${tag}"
-          echo "::set-output name=prerelease::${prerelease}"
-          echo "::set-output name=annotation_title::${annotation_title}"
+          echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" | tee -a "$GITHUB_OUTPUT"
+          echo "annotation_title=$annotation_title" | tee -a "$GITHUB_OUTPUT"
+          echo "TARGET_TAG=$tag" | tee -a "$GITHUB_ENV"
 
           # Prepare annotation body as a file for the next step
           #
-          # * The GitHub Release render the text in this file as markdown
-          # * The file is needed because :set-output only supports single lines
+          # * The GitHub Release renders the text in this file as markdown
+          # * The file is needed because GITHUB_OUTPUT only supports single lines
           # * The `perl -pe` removes RPM-style date headers from the CHANGELOG,
           #   because they don't render well as markdown on the Release page
           #
@@ -139,15 +139,18 @@ jobs:
     steps:
       - name: Get tag & annotation info (${{github.ref}})
         id: tag-check
-        run: echo "::set-output name=tag::${GITHUB_REF/refs\/tags\//}"
+        run: |
+          tag="${GITHUB_REF/refs\/tags\//}"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
       - name: Trigger RPM release workflow (${{ matrix.os }})
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           TARGET_TAG: ${{ steps.tag-check.outputs.tag }}
         with:
           github-token: ${{ secrets.SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE }}
           script: |
+            console.log( `== Building tag: '${ process.env.TARGET_TAG }' for os '${{ matrix.os}}'` )
             const [owner, repo] = process.env.TARGET_REPO.split('/')
             await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
               owner: owner,
@@ -165,17 +168,17 @@ jobs:
             })
 
   deploy-to-puppet-forge:
-    name: Deploy PuppetForge Release
+    name: 'Deploy PuppetForge Release'
     needs: [ create-github-release ]
     if: (github.repository_owner == 'simp') && (needs.create-github-release.outputs.prerelease != 'yes')
     runs-on: ubuntu-latest
     env:
       PUPPETFORGE_API_TOKEN: ${{ secrets.PUPPETFORGE_API_TOKEN }}
-      FORGE_USER_AGENT: GitHubActions-ForgeReleng-Workflow/0.4.0 (Purpose/forge-ops-for-${{ github.event.repository.name }})
+      FORGE_USER_AGENT: GitHubActions-ForgeReleng-Workflow/0.4.1 (Purpose/forge-ops-for-${{ github.event.repository.name }})
       FORGE_API_URL: https://forgeapi.puppet.com/v3/releases
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,8 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
-# PE 2019.8     6.22     2.5.7   2022-12 (LTS)
+# PE 2019.8     6.28     2.5.7   2023-07 (LTS)
+# PE 2021.7     7.20     2.7.6   TBD (LTS)
 ---
 
 stages:
@@ -42,20 +43,16 @@ variables:
   BUNDLE_BIN:        .vendor/gem_install/bin
   BUNDLE_NO_PRUNE:   'true'
 
+.snippets:
+  before_beaker_google:
+    # Logic for beaker-google environments
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script05[collapsed=true]\r\e[0KGCP environment checks"
+    - "if [ \"$BEAKER_HYPERVISOR\" ==  google ]; then mkdir -p ~/.ssh; chmod 700 ~/.ssh; test -f ~/.ssh/google_compute_engine || ssh-keygen -f ~/.ssh/google_compute_engine < /dev/null; echo 'gem \"beaker-google\"' >> Gemfile.local ; fi"
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script05\r\e[0K"
 
-# bundler dependencies and caching
-#
-# - Cache bundler gems between pipelines foreach Ruby version
-# - Try to use cached and local resources before downloading dependencies
-# --------------------------------------
-.setup_bundler_env: &setup_bundler_env
-  cache:
-    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
-    paths:
-      - '.vendor'
-  before_script:
+  before:
     # Print important environment variables that may affect this job
-    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX/); pad=((e.map{|x| x.size}.max||0)+1); e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)" || :'
+    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX|GOOGLE/); pad=((e.map{|x| x.size}.max||0)+1); e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)" || :'
 
     - echo -e "\e[0Ksection_start:`date +%s`:before_script10[collapsed=true]\r\e[0KDiagnostic ruby & gem information"
     # Diagnostic ruby & gem information
@@ -95,6 +92,19 @@ variables:
     - 'bundle show sync || :'
     - 'bundle exec gem list sync || :'
     - echo -e "\e[0Ksection_end:`date +%s`:before_script40\r\e[0K"
+
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
+.setup_bundler_env: &setup_bundler_env
+  cache:
+    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
+    paths:
+      - '.vendor'
+  before_script:
+    !reference [.snippets, before]
 
 
 # Assign a matrix level when your test will run.  Heavier jobs get higher numbers
@@ -243,6 +253,8 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet7'
     MATRIX_RUBY_VERSION: '2.7'
 
+
+
 # Testing Environments
 #-----------------------------------------------------------------------
 
@@ -263,17 +275,27 @@ variables:
   script:
     - 'bundle exec rake spec'
 
+.beaker: &beaker
+  image: ruby:2.7.2  # must be 2.7.2 if running in GCP
+  tags:
+    - beaker
+  before_script:
+    - !reference [.snippets, before_beaker_google]
+    - !reference [.snippets, before]
+
+
+
 .acceptance_base: &acceptance_base
   stage: 'acceptance'
-  tags: ['beaker']
   <<: *setup_bundler_env
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
+  <<: *beaker
 
 .compliance_base: &compliance_base
   stage: 'compliance'
-  tags: ['beaker']
   <<: *setup_bundler_env
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
+  <<: *beaker
 
 
 # Pipeline / testing matrix
@@ -289,7 +311,7 @@ releng_checks:
     - 'bundle exec rake check:dot_underscore'
     - 'bundle exec rake check:test_file'
     - 'bundle exec rake pkg:check_version'
-    - 'bundle exec rake pkg:compare_latest_tag'
+    - 'bundle exec rake pkg:compare_latest_tag[,true]'
     - 'bundle exec rake pkg:create_tag_changelog'
     - 'bundle exec pdk build --force --target-dir=dist'
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.28.0', '< 2']
+  gem 'bcrypt_pbkdf'
 end
 
 # Evaluate extra gemfiles if they exist


### PR DESCRIPTION
This patch updates GHA workflows to use GCP as a hypervisor when
BEAKER_HYPERVISOR is `google`

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.