### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.4.0
+- Add RockyLinux 8 support
+
 * Mon Sep 26 2022 Trevor Vaughan <trevor@sicura.us> - 7.3.0
 - Added:
   - The module now supports Amazon Linux 2

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -27,7 +27,7 @@ class krb5::client (
   # There's a possibility that the krb5::kdc class has already created the
   # default one and you can only declare one realm with a given name.
 
-  if getvar('krb5::kdc::auto_initialize') and (getvar('krb5::kdc::auto_realm') == $facts['domain']) {
+  if getvar('krb5::kdc::auto_initialize') and (getvar('krb5::kdc::auto_realm') == $facts['networking']['domain']) {
     $_use_default = false
   }
   else {
@@ -42,7 +42,7 @@ class krb5::client (
     }
 
     $_realms = {
-      $facts['domain'] => {
+      $facts['networking']['domain'] => {
         admin_server => $_default_kdc
       }
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,7 +26,7 @@
 class krb5::config (
   Stdlib::Absolutepath $config_dir               = '/etc/krb5.conf.simp.d',
   String               $default_realm            = inline_template('<%= @domain.upcase %>'),
-  Array[String]        $realm_domains            = [ ".${facts['domain']}", $facts['domain'] ],
+  Array[String]        $realm_domains            = [ ".${facts['networking']['domain']}", $facts['networking']['domain'] ],
   Boolean              $dns_lookup_realm         = false,
   Boolean              $dns_lookup_kdc           = true,
   String               $renew_lifetime           = '7d',

--- a/manifests/kdc.pp
+++ b/manifests/kdc.pp
@@ -72,7 +72,7 @@ class krb5::kdc (
   Boolean              $firewall                   = $krb5::firewall,
   Boolean              $haveged                    = $krb5::haveged,
   Boolean              $auto_initialize            = true,
-  String               $auto_realm                 = $facts['domain'],
+  String               $auto_realm                 = $facts['networking']['domain'],
   String               $auto_management_principal  = 'puppet_auto',
   Boolean              $auto_generate_host_keytabs = true
 ) inherits krb5 {
@@ -107,7 +107,7 @@ class krb5::kdc (
 
     if !defined(Krb5::Setting::Realm[$auto_realm]) {
       krb5::setting::realm { $auto_realm:
-        admin_server => $facts['fqdn']
+        admin_server => $facts['networking']['fqdn']
       }
     }
 

--- a/manifests/kdc/auto_keytabs.pp
+++ b/manifests/kdc/auto_keytabs.pp
@@ -63,7 +63,7 @@ class krb5::kdc::auto_keytabs (
   Boolean                        $all_known       = false,
   String                         $user            = 'root',
   String                         $group           = 'puppet',
-  String                         $realms          = simplib::lookup('krb5::kdc::auto_realm', { 'default_value' => $facts['domain'] }),
+  String                         $realms          = simplib::lookup('krb5::kdc::auto_realm', { 'default_value' => $facts['networking']['domain'] }),
   Array[String]                  $global_services = [],
   Boolean                        $purge           = true,
   Hash[String,

--- a/manifests/kdc/selinux_hotfix.pp
+++ b/manifests/kdc/selinux_hotfix.pp
@@ -7,7 +7,7 @@
 class krb5::kdc::selinux_hotfix {
   assert_private()
 
-  if $facts['selinux_current_mode'] and ($facts['selinux_current_mode'] != 'disabled') {
+  if $facts['os']['selinux']['current_mode'] and ($facts['os']['selinux']['current_mode'] != 'disabled') {
     simplib::assert_optional_dependency($module_name, 'vox_selinux')
 
     $_config_dir = $krb5::kdc::config_dir

--- a/manifests/keytab.pp
+++ b/manifests/keytab.pp
@@ -17,7 +17,7 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class krb5::keytab (
-  $keytab_source = "puppet:///modules/krb5_files/keytabs/${facts['fqdn']}",
+  $keytab_source = "puppet:///modules/krb5_files/keytabs/${facts['networking']['fqdn']}",
   $owner         = 'root',
   $group         = 'root',
   $mode          = '0400'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-krb5",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "author": "SIMP Team",
   "summary": "Puppet management of the MIT kerberos stack",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "simp": {
@@ -60,6 +60,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.